### PR TITLE
Fixed logout issues

### DIFF
--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -2,6 +2,7 @@ import React, { useContext } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { UserLogout } from "../api/UserAPI";
 import AuthContext from "../context/AuthProvider";
+import { deleteCookie } from "../functions/cookies";
 
 const Navbar = (): JSX.Element => {
     const auth = useContext(AuthContext);
@@ -13,6 +14,8 @@ const Navbar = (): JSX.Element => {
         UserLogout(
             auth.axiosInstance,
             (_) => {
+                // also delete from client side (sometimes doesn't get deleted properly otherwise, maybe racing on the server?)
+                deleteCookie("jwt");
                 auth.setAuth({ user: undefined, loggedIn: false });
                 navigate("/");
             },

--- a/client/src/functions/__tests__/cookies.test.ts
+++ b/client/src/functions/__tests__/cookies.test.ts
@@ -1,4 +1,4 @@
-import { getCookie, setCookie } from "../cookies";
+import { deleteCookie, getCookie, setCookie } from "../cookies";
 
 const writeCookie = (key: string, value: string): void => {
     // https://stackoverflow.com/a/51978914
@@ -31,6 +31,17 @@ describe("setCookie", () => {
         let value: string = "cookie-value!";
 
         setCookie(key, value);
-        expect(window.document.cookie).toBe(`${key}=${value}; SameSite=Lax`);
+        expect(window.document.cookie).toBe(`${key}=${value}; SameSite=Lax;`);
+    });
+});
+
+describe("deleteCookie", () => {
+    it("single cookie", () => {
+        let key: string = "test-cookie";
+        let value: string = "not undefined!";
+
+        writeCookie(key, value);
+        deleteCookie("jwt");
+        expect(getCookie(key)).toBe(undefined);
     });
 });

--- a/client/src/functions/cookies.ts
+++ b/client/src/functions/cookies.ts
@@ -9,5 +9,9 @@ export const getCookie = (name: string): string | undefined => {
 };
 
 export const setCookie = (name: string, value: string): void => {
-    document.cookie = `${name}=${value}; SameSite=Lax`;
+    document.cookie = `${name}=${value}; SameSite=Lax;`;
+};
+
+export const deleteCookie = (name: string): void => {
+    document.cookie = `${name}=; Max-Age=-1; SameSite=Strict;`;
 };

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -5,6 +5,7 @@ import { UserDelete, UserGetSelf, UserPatch } from "../api/UserAPI";
 import Modal from "../components/Modal";
 import { validEmail, validPassword, validUsername } from "../components/regex";
 import AuthContext from "../context/AuthProvider";
+import { deleteCookie } from "../functions/cookies";
 import { toTitleCase } from "../functions/strings";
 import { BaseButton } from "../styles";
 
@@ -248,10 +249,9 @@ const Settings = (): JSX.Element => {
         UserDelete(
             auth.axiosInstance,
             (_) => {
-                auth.setAuth({
-                    user: undefined,
-                    loggedIn: false,
-                });
+                // also delete from client side (sometimes doesn't get deleted properly otherwise, maybe racing on the server?)
+                deleteCookie("jwt");
+                auth.setAuth({ user: undefined, loggedIn: false });
                 navigate("/");
             },
             (err) => {


### PR DESCRIPTION
I suspect the issue is to do with the backend racing and setting and deleting the cookie within the same (few) frame(s)?

Issue only occurs on Heroku servers but not in local development.

Patched it by letting the client *also* delete the cookie on the client side. This does not solve the (potential) underlying issue but does hide it. However, impossible to test whether this fix 100% fixes it unless we deploy it.