### PR TITLE
Removed email changing

### DIFF
--- a/client/docs.md
+++ b/client/docs.md
@@ -95,9 +95,8 @@ The user can see their user page here. (to be implemented)
 The user can perform the following actions:
 
 1. Change username
-2. Change email
-3. Change password
-4. Delete account
+2. Change password
+3. Delete account
 
 ## Logout
 

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import styled, { css } from "styled-components";
 import { UserDelete, UserGetSelf, UserPatch } from "../api/UserAPI";
 import Modal from "../components/Modal";
-import { validEmail, validPassword, validUsername } from "../components/regex";
+import { validPassword, validUsername } from "../components/regex";
 import AuthContext from "../context/AuthProvider";
 import { toTitleCase } from "../functions/strings";
 import { BaseButton } from "../styles";
@@ -13,14 +13,12 @@ import { BaseButton } from "../styles";
 // validityChecks object in Settings
 interface Fields {
     name: string;
-    email: string;
     password: string;
     confirm_password: string;
 }
 
 const defaultFields: Fields = {
     name: "",
-    email: "",
     password: "",
     confirm_password: "",
 };
@@ -28,7 +26,7 @@ const defaultFields: Fields = {
 // ensure these keys match the keys of interface Fields
 // keyof Fields is there to prevent extra keys (but cannot prevent missing/duplicate keys, no other better yet simple solution)
 // https://stackoverflow.com/questions/43909566/get-keys-of-a-typescript-interface-as-array-of-strings
-const keys: (keyof Fields)[] = ["name", "email", "password"];
+const keys: (keyof Fields)[] = ["name", "password"];
 
 const centered = css`
     text-align: center;
@@ -152,10 +150,6 @@ const Settings = (): JSX.Element => {
             const name: string = fields["name"];
             return validUsername.test(name);
         },
-        email: () => {
-            const email: string = fields["email"];
-            return validEmail.test(email);
-        },
         password: () => {
             const name: string = auth.auth.user || "";
             const password: string = fields["password"];
@@ -170,13 +164,13 @@ const Settings = (): JSX.Element => {
     };
 
     useEffect(() => {
-        // get user name and email and populate fields on page load
+        // get user name and populate fields on page load
         UserGetSelf(
             auth.axiosInstance,
             (response) => {
                 const data = response.data;
                 setFields((f) => {
-                    return { ...f, name: data["name"], email: data["email"] };
+                    return { ...f, name: data["name"] };
                 });
             },
             (err) => {


### PR DESCRIPTION
Users have found it weird that they can seemingly change their emails without confirmation, thus we responded... by completely removing the ability to change emails!

Maybe we'll add it back in the future with actual email verification, maybe.