### PR TITLE
Use Preloader more

### DIFF
--- a/client/src/components/PreLoader.tsx
+++ b/client/src/components/PreLoader.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import styled, { keyframes, Keyframes } from "styled-components";
 
 const Container = styled.div`
@@ -132,18 +133,46 @@ const Bar = styled.div<{ index: number }>`
     width: 1rem;
 `;
 
+// 5 seconds is the default timeout duration
+const defaultTimeoutDuration: number = 1000 * 5;
+
 /**
  * PreLoader for the website.
  *
  * Inspiration taken from "CSS Stairs Loader" from this website.
  * Code is much less hard coded than the example there.
  * https://steelkiwi.com/blog/30-most-captivating-preloaders-for-website/
+ *
+ * loading should initially be true and setLoading should ever only be set to false.
+ * timeoutDuration is optional and defaults to 5 seconds.
+ * setTimeoutObject can be used to retrieve the timeout object if needed for killing early (for whatever reason)
  */
-const PreLoader = ({ loading }: { loading: boolean }): JSX.Element => {
+const PreLoader = ({
+    loading,
+    setLoading,
+    timeoutDuration,
+    setTimeoutObject,
+}: {
+    loading: boolean;
+    setLoading: React.Dispatch<React.SetStateAction<boolean>>;
+    timeoutDuration?: number;
+    setTimeoutObject?: React.Dispatch<React.SetStateAction<NodeJS.Timeout>>;
+}): JSX.Element => {
+    useEffect(() => {
+        const loadingTimeout: NodeJS.Timeout = setTimeout(() => {
+            setLoading(false);
+        }, timeoutDuration ?? defaultTimeoutDuration);
+
+        if (setTimeoutObject !== undefined) {
+            // done so that the user of this Preloader has the option to retrieve this timeout to kill it earlier if needed (using clearTimeout)
+            setTimeoutObject(loadingTimeout);
+        }
+    }, []);
+
     if (!loading) {
         return (
             <Container>
-                <BigText>This page failed to load.</BigText>
+                <BigText>Page or resource failed to load.</BigText>
                 <Text>Check if you have permissions or try again in a while.</Text>
             </Container>
         );

--- a/client/src/components/__tests__/Preloader.test.tsx
+++ b/client/src/components/__tests__/Preloader.test.tsx
@@ -3,11 +3,11 @@ import PreLoader from "../PreLoader";
 
 describe("Preloader", () => {
     it("loading", () => {
-        render(<PreLoader {...{ loading: true }} />);
+        render(<PreLoader {...{ loading: true, setLoading: jest.fn() }} />);
         expect(screen.queryByText("Loading...")).toBeVisible();
     });
     it("not loading", () => {
-        render(<PreLoader {...{ loading: false }} />);
-        expect(screen.queryByText("This page failed to load.")).toBeVisible();
+        render(<PreLoader {...{ loading: false, setLoading: jest.fn() }} />);
+        expect(screen.queryByText("Page or resource failed to load.")).toBeVisible();
     });
 });

--- a/client/src/pages/Project.tsx
+++ b/client/src/pages/Project.tsx
@@ -147,15 +147,10 @@ const Project = (): JSX.Element => {
             return;
         }
 
-        const loadingTimeout: NodeJS.Timeout = setTimeout(() => {
-            setLoading(false);
-        }, 1000 * 5);
-
         data.getProject(projectid).then(([project, tasks]) => {
             setProject(project);
             setTasks(tasks);
             setLoading(false);
-            clearTimeout(loadingTimeout);
         });
 
         // including data.getProject and id will cause this to continuously fire
@@ -168,7 +163,7 @@ const Project = (): JSX.Element => {
                 <Row className="my-2">
                     <Link to="/projects">⬅️ Back to Projects</Link>
                 </Row>
-                <PreLoader {...{ loading }} />
+                <PreLoader {...{ loading, setLoading }} />
             </Container>
         );
     }


### PR DESCRIPTION
Changes:
1. Made preloader more flexible and now preloader is directly responsible for setting the timeout. Would make it easier to reuse for other components.

Preloader is used on the following pages/components:
1. Project page ✅
2. Project create (after creation and waiting for the link -> might have to construct a simpler & smaller preloader for this)
3. Data provider's information pulling on page load
4. Loading of tasks for user dashboard (after data provider has loaded in data)
5. Projects list page (after data provider has loaded in data)

Other relevant but less related changes:
1. Removed UserGetSelf API call from Settings page because we no longer need the email, thus we can just get the username from the auth context directly.