### PR TITLE
Server Events

### DIFF
--- a/api.md
+++ b/api.md
@@ -729,7 +729,7 @@ Input:
 
 ```typescript
 type input = {
-    taskid: string;
+    eventid: string;
     name?: string;
     start?: string; // ISO 8601 format
     end?: string; // ISO 8601 format

--- a/api.md
+++ b/api.md
@@ -742,7 +742,7 @@ Output: None
 
 DELETE "/event_delete"
 
-Input: Query parameter of eventid of event to be deleted.
+Input: Query parameter of eventid of event to be deleted, and projectid (if associated with a project).
 
 ## Definitions
 

--- a/api.md
+++ b/api.md
@@ -384,7 +384,7 @@ Status Code: 200 or 400
 
 GET "/project_get"
 
-This will get the project's name, description and creation time.
+This will get the project's name, description and creation time, events, members, tasks.
 
 Input: Query parameters of "projectid"
 
@@ -400,7 +400,7 @@ Output:
 {
   "creationTime": string,
   "description": string,
-  "events": {},
+  "events": Event[],
   "members": [
       {
           "name": string,

--- a/api.md
+++ b/api.md
@@ -623,7 +623,7 @@ For tags array, do parse the changes similarly to assignedTo.
 GET "/task_get_all"
 
 Get All User Tasks: Leave projectid blank
-Get All Project Tasks: Put Relevant projectId
+Get All Project Tasks: Put relevant projectId
 
 Input: Query parameters of "projectid"
 
@@ -658,6 +658,91 @@ Input: A JSON body with the following **required** parameters.
   tasks: string[];
 }
 ```
+
+### Event Create
+
+POST "/event_create"
+
+This will create a personal event or project event.
+
+1. If _no_ projectid is passed in, the task will be created for the current user.
+2. If a projectid is passed in, the task will be created for the project with that projectid.
+
+Input:
+
+```typescript
+type input = {
+    name: string;
+    start: string; // ISO 8601 format
+    end: string; // ISO 8601 format
+    projectid?: string;
+};
+```
+
+Output:
+
+```typescript
+type output = {
+    eventid: string; // id of the created event
+};
+```
+
+### Event Get
+
+GET "/event_get"
+
+Input: Query parameters of "eventid".
+
+Output:
+
+```typescript
+type output = {
+    id: string; // id of event
+    name: string;
+    start: string; // ISO 8601 format
+    end: string; // ISO 8601 format
+};
+```
+
+### Event Get All
+
+GET "/event_get_all"
+
+Get All User Events: Leave projectid blank
+Get All Project Events: Put relevant projectid
+
+Input: Query parameters of "projectid"
+
+Output:
+
+```typescript
+type output = {
+    events: Event[];
+};
+```
+
+### Event Modify
+
+PATCH "/event_modify"
+
+Input:
+
+```typescript
+type input = {
+    taskid: string;
+    name?: string;
+    start?: string; // ISO 8601 format
+    end?: string; // ISO 8601 format
+};
+```
+
+Output: None
+
+### Event Delete
+
+DELETE "/event_delete"
+
+Input: Query parameter of eventid of event to be deleted.
 
 ## Definitions
 

--- a/main.go
+++ b/main.go
@@ -75,7 +75,7 @@ func handleRoutes(URL string, router *gin.Engine, userController controllers.Use
 	v1.GET("/event_get", handlers.EventGet(eventController, jwtParser))
 	v1.GET("/event_get_all", handlers.EventGetAll(userController, projectController, eventController, jwtParser))
 	v1.PATCH("/event_modify", handlers.EventModify(eventController, jwtParser))
-	v1.DELETE("/event_delete", handlers.EventDelete())
+	v1.DELETE("/event_delete", handlers.EventDelete(userController, projectController, eventController, jwtParser))
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -57,7 +57,7 @@ func handleRoutes(URL string, router *gin.Engine, userController controllers.Use
 	v1.PATCH("/user_reject", handlers.UserRejectProject(userController, projectController, jwtParser))
 
 	v1.POST("/project_create", handlers.ProjectCreate(userController, projectController, jwtParser))
-	v1.GET("/project_get", handlers.ProjectGet(userController, projectController, taskController, jwtParser))
+	v1.GET("/project_get", handlers.ProjectGet(userController, projectController, taskController, eventController, jwtParser))
 	v1.GET("/project_get_all", handlers.ProjectGetAll(userController, projectController, jwtParser))
 	v1.PATCH("/project_modify", handlers.ProjectModify(projectController, jwtParser))
 	v1.PATCH("/project_invite", handlers.ProjectInviteUser(userController, jwtParser))

--- a/main.go
+++ b/main.go
@@ -71,7 +71,7 @@ func handleRoutes(URL string, router *gin.Engine, userController controllers.Use
 	v1.PATCH("/task_modify", handlers.TaskModify(userController, taskController, jwtParser))
 	v1.GET("/task_get_all", handlers.TaskGetAll(userController, projectController, taskController, jwtParser))
 
-	v1.POST("/event_create", handlers.EventCreate(userController, eventController, jwtParser))
+	v1.POST("/event_create", handlers.EventCreate(userController, projectController, eventController, jwtParser))
 	v1.GET("/event_get", handlers.EventGet())
 	v1.GET("/event_get_all", handlers.EventGetAll())
 	v1.PATCH("/event_modify", handlers.EventModify())

--- a/main.go
+++ b/main.go
@@ -74,7 +74,7 @@ func handleRoutes(URL string, router *gin.Engine, userController controllers.Use
 	v1.POST("/event_create", handlers.EventCreate(userController, projectController, eventController, jwtParser))
 	v1.GET("/event_get", handlers.EventGet(eventController, jwtParser))
 	v1.GET("/event_get_all", handlers.EventGetAll(userController, projectController, eventController, jwtParser))
-	v1.PATCH("/event_modify", handlers.EventModify())
+	v1.PATCH("/event_modify", handlers.EventModify(eventController, jwtParser))
 	v1.DELETE("/event_delete", handlers.EventDelete())
 }
 

--- a/main.go
+++ b/main.go
@@ -71,7 +71,7 @@ func handleRoutes(URL string, router *gin.Engine, userController controllers.Use
 	v1.PATCH("/task_modify", handlers.TaskModify(userController, taskController, jwtParser))
 	v1.GET("/task_get_all", handlers.TaskGetAll(userController, projectController, taskController, jwtParser))
 
-	v1.POST("/event_create", handlers.EventCreate(eventController, jwtParser))
+	v1.POST("/event_create", handlers.EventCreate(userController, eventController, jwtParser))
 	v1.GET("/event_get", handlers.EventGet())
 	v1.GET("/event_get_all", handlers.EventGetAll())
 	v1.PATCH("/event_modify", handlers.EventModify())

--- a/main.go
+++ b/main.go
@@ -72,7 +72,7 @@ func handleRoutes(URL string, router *gin.Engine, userController controllers.Use
 	v1.GET("/task_get_all", handlers.TaskGetAll(userController, projectController, taskController, jwtParser))
 
 	v1.POST("/event_create", handlers.EventCreate(userController, projectController, eventController, jwtParser))
-	v1.GET("/event_get", handlers.EventGet())
+	v1.GET("/event_get", handlers.EventGet(eventController, jwtParser))
 	v1.GET("/event_get_all", handlers.EventGetAll())
 	v1.PATCH("/event_modify", handlers.EventModify())
 	v1.DELETE("/event_delete", handlers.EventDelete())

--- a/main.go
+++ b/main.go
@@ -37,7 +37,7 @@ func handleRoutes(URL string, router *gin.Engine, userController controllers.Use
 	v1.POST("/signup", handlers.UserSignup(userController, jwtParser, mailer))
 	v1.POST("/verify", handlers.UserVerify(userController, jwtParser))
 	v1.POST("/login", handlers.UserLogin(userController, jwtParser))
-	v1.GET("/refresh-jwt", handlers.UserRefreshJWT(userController, jwtParser))
+	v1.GET("/refresh_jwt", handlers.UserRefreshJWT(userController, jwtParser))
 	v1.DELETE("/logout", handlers.UserLogout(userController, jwtParser))
 
 	v1.POST("/forgot_pw", handlers.UserForgotPW(userController, mailer))

--- a/main.go
+++ b/main.go
@@ -73,7 +73,7 @@ func handleRoutes(URL string, router *gin.Engine, userController controllers.Use
 
 	v1.POST("/event_create", handlers.EventCreate(userController, projectController, eventController, jwtParser))
 	v1.GET("/event_get", handlers.EventGet(eventController, jwtParser))
-	v1.GET("/event_get_all", handlers.EventGetAll())
+	v1.GET("/event_get_all", handlers.EventGetAll(userController, projectController, eventController, jwtParser))
 	v1.PATCH("/event_modify", handlers.EventModify())
 	v1.DELETE("/event_delete", handlers.EventDelete())
 }

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 	"github.com/joho/godotenv"
 )
 
-func handleRoutes(URL string, router *gin.Engine, userController controllers.UserController, projectController controllers.ProjectController, taskController controllers.TaskController, jwtParser *auth.JWTParser, mailer *mailer.Mailer) {
+func handleRoutes(URL string, router *gin.Engine, userController controllers.UserController, projectController controllers.ProjectController, taskController controllers.TaskController, eventController controllers.EventController, jwtParser *auth.JWTParser, mailer *mailer.Mailer) {
 	// serve React build at root
 	// make sure to re-build the React client after every change
 	// run `make bc`
@@ -71,7 +71,7 @@ func handleRoutes(URL string, router *gin.Engine, userController controllers.Use
 	v1.PATCH("/task_modify", handlers.TaskModify(userController, taskController, jwtParser))
 	v1.GET("/task_get_all", handlers.TaskGetAll(userController, projectController, taskController, jwtParser))
 
-	v1.POST("/event_create", handlers.EventCreate())
+	v1.POST("/event_create", handlers.EventCreate(eventController, jwtParser))
 	v1.GET("/event_get", handlers.EventGet())
 	v1.GET("/event_get_all", handlers.EventGetAll())
 	v1.PATCH("/event_modify", handlers.EventModify())
@@ -128,9 +128,10 @@ func main() {
 	userController := controllers.NewU(client, URL)
 	projectController := controllers.NewP(client, URL)
 	taskController := controllers.NewT(client, URL)
+	eventController := controllers.NewE(client, URL)
 	jwtParser := auth.New(jwtSecret)
 	mailer := mailer.New("OrgaNiUS", emailSender, sendGridKey)
-	handleRoutes(URL, router, *userController, *projectController, *taskController, jwtParser, mailer)
+	handleRoutes(URL, router, *userController, *projectController, *taskController, *eventController, jwtParser, mailer)
 
 	log.Print("Server booted up!")
 

--- a/main.go
+++ b/main.go
@@ -70,6 +70,12 @@ func handleRoutes(URL string, router *gin.Engine, userController controllers.Use
 	v1.DELETE("/task_delete", handlers.TaskDelete(userController, projectController, taskController, jwtParser))
 	v1.PATCH("/task_modify", handlers.TaskModify(userController, taskController, jwtParser))
 	v1.GET("/task_get_all", handlers.TaskGetAll(userController, projectController, taskController, jwtParser))
+
+	v1.POST("/event_create", handlers.EventCreate())
+	v1.GET("/event_get", handlers.EventGet())
+	v1.GET("/event_get_all", handlers.EventGetAll())
+	v1.PATCH("/event_modify", handlers.EventModify())
+	v1.DELETE("/event_delete", handlers.EventDelete())
 }
 
 func main() {

--- a/server/controllers/event.go
+++ b/server/controllers/event.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/OrgaNiUS/OrgaNiUS/server/models"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 const (
@@ -18,4 +19,16 @@ func (c *EventController) EventCreate(ctx context.Context, event *models.Event) 
 	event.Id = id
 
 	return nil
+}
+
+func (c *EventController) EventMapToArray(ctx context.Context, events []string) []models.Event {
+	size := len(events)
+	ids := make([]primitive.ObjectID, size)
+	result := make([]models.Event, size)
+	for i, eventid := range events {
+		id, _ := primitive.ObjectIDFromHex(eventid)
+		ids[i] = id
+	}
+	c.Collection(eventCollection).FindAll(ctx, ids, &result)
+	return result
 }

--- a/server/controllers/event.go
+++ b/server/controllers/event.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 
+	"github.com/OrgaNiUS/OrgaNiUS/server/functions"
 	"github.com/OrgaNiUS/OrgaNiUS/server/models"
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
@@ -40,4 +42,29 @@ func (c *EventController) EventMapToArray(ctx context.Context, events []string) 
 	}
 	c.Collection(eventCollection).FindAll(ctx, ids, &result)
 	return result
+}
+
+func (c *EventController) EventModify(ctx context.Context, eventid primitive.ObjectID, name, start, end *string) error {
+	params := bson.D{}
+	if name != nil {
+		params = append(params, bson.E{Key: "name", Value: *name})
+	}
+	if start != nil {
+		startTime, err := functions.StringToTime(*start)
+		if err != nil {
+			return errors.New("bad start time")
+		}
+		params = append(params, bson.E{Key: "start", Value: startTime})
+	}
+	if end != nil {
+		endTime, err := functions.StringToTime(*end)
+		if err != nil {
+			return errors.New("bad end time")
+		}
+		params = append(params, bson.E{Key: "end", Value: endTime})
+	}
+
+	update := bson.D{{Key: "$set", Value: params}}
+	c.Collection(eventCollection).UpdateByID(ctx, eventid, update)
+	return nil
 }

--- a/server/controllers/event.go
+++ b/server/controllers/event.go
@@ -1,0 +1,21 @@
+package controllers
+
+import (
+	"context"
+
+	"github.com/OrgaNiUS/OrgaNiUS/server/models"
+)
+
+const (
+	eventCollection = "events"
+)
+
+func (c *EventController) EventCreate(ctx context.Context, event *models.Event) error {
+	id, err := c.Collection(eventCollection).InsertOne(ctx, event)
+	if err != nil {
+		return err
+	}
+	event.Id = id
+
+	return nil
+}

--- a/server/controllers/event.go
+++ b/server/controllers/event.go
@@ -68,3 +68,8 @@ func (c *EventController) EventModify(ctx context.Context, eventid primitive.Obj
 	c.Collection(eventCollection).UpdateByID(ctx, eventid, update)
 	return nil
 }
+
+func (c *EventController) EventDelete(ctx context.Context, eventid primitive.ObjectID) error {
+	_, err := c.Collection(eventCollection).DeleteByID(ctx, eventid)
+	return err
+}

--- a/server/controllers/event.go
+++ b/server/controllers/event.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"errors"
 
 	"github.com/OrgaNiUS/OrgaNiUS/server/models"
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -19,6 +20,14 @@ func (c *EventController) EventCreate(ctx context.Context, event *models.Event) 
 	event.Id = id
 
 	return nil
+}
+
+func (c *EventController) EventGet(ctx context.Context, eventid string) (*models.Event, error) {
+	if eventid == "" {
+		return nil, errors.New("cannot leave id empty")
+	}
+	event, err := c.Collection(eventCollection).FindOne(ctx, eventid)
+	return event, err
 }
 
 func (c *EventController) EventMapToArray(ctx context.Context, events []string) []models.Event {

--- a/server/controllers/eventControllers.go
+++ b/server/controllers/eventControllers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/OrgaNiUS/OrgaNiUS/server/models"
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -11,6 +12,8 @@ import (
 
 type EventCollectionInterface interface {
 	InsertOne(ctx context.Context, event *models.Event) (primitive.ObjectID, error)
+
+	FindAll(ctx context.Context, ids []primitive.ObjectID, events *[]models.Event) error
 }
 
 type EventCollection struct {
@@ -24,6 +27,16 @@ func (c *EventCollection) InsertOne(ctx context.Context, event *models.Event) (p
 	}
 	id := result.InsertedID.(primitive.ObjectID)
 	return id, nil
+}
+
+func (c *EventCollection) FindAll(ctx context.Context, ids []primitive.ObjectID, events *[]models.Event) error {
+	params := bson.D{{Key: "_id", Value: bson.D{{Key: "$in", Value: ids}}}}
+	cursor, err := c.eventCollection.Find(ctx, params)
+	if err != nil {
+		return err
+	}
+	cursor.All(ctx, events)
+	return nil
 }
 
 type EventController struct {

--- a/server/controllers/eventControllers.go
+++ b/server/controllers/eventControllers.go
@@ -1,0 +1,44 @@
+package controllers
+
+import (
+	"context"
+
+	"github.com/OrgaNiUS/OrgaNiUS/server/models"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+type EventCollectionInterface interface {
+	InsertOne(ctx context.Context, event *models.Event) (primitive.ObjectID, error)
+}
+
+type EventCollection struct {
+	eventCollection *mongo.Collection
+}
+
+func (c *EventCollection) InsertOne(ctx context.Context, event *models.Event) (primitive.ObjectID, error) {
+	result, err := c.eventCollection.InsertOne(ctx, event)
+	if err != nil {
+		return primitive.NilObjectID, err
+	}
+	id := result.InsertedID.(primitive.ObjectID)
+	return id, nil
+}
+
+type EventController struct {
+	Collection func(name string, opts ...*options.CollectionOptions) EventCollectionInterface
+	URL        string
+}
+
+func NewE(client *mongo.Client, URL string) *EventController {
+	database := client.Database(databaseName)
+	return &EventController{
+		func(name string, opts ...*options.CollectionOptions) EventCollectionInterface {
+			return &EventCollection{
+				database.Collection(name, opts...),
+			}
+		},
+		URL,
+	}
+}

--- a/server/controllers/eventControllers.go
+++ b/server/controllers/eventControllers.go
@@ -18,6 +18,8 @@ type EventCollectionInterface interface {
 	FindAll(ctx context.Context, ids []primitive.ObjectID, events *[]models.Event) error
 
 	UpdateByID(ctx context.Context, id primitive.ObjectID, params bson.D) (*mongo.UpdateResult, error)
+
+	DeleteByID(ctx context.Context, id primitive.ObjectID) (int64, error)
 }
 
 type EventCollection struct {
@@ -60,6 +62,15 @@ func (c *EventCollection) UpdateByID(ctx context.Context, id primitive.ObjectID,
 		return nil, err
 	}
 	return result, err
+}
+
+func (c *EventCollection) DeleteByID(ctx context.Context, id primitive.ObjectID) (int64, error) {
+	params := bson.D{{Key: "_id", Value: id}}
+	result, err := c.eventCollection.DeleteOne(ctx, params)
+	if err != nil {
+		return -1, err
+	}
+	return result.DeletedCount, nil
 }
 
 type EventController struct {

--- a/server/controllers/eventControllers.go
+++ b/server/controllers/eventControllers.go
@@ -16,6 +16,8 @@ type EventCollectionInterface interface {
 	FindOne(ctx context.Context, id string) (*models.Event, error)
 
 	FindAll(ctx context.Context, ids []primitive.ObjectID, events *[]models.Event) error
+
+	UpdateByID(ctx context.Context, id primitive.ObjectID, params bson.D) (*mongo.UpdateResult, error)
 }
 
 type EventCollection struct {
@@ -50,6 +52,14 @@ func (c *EventCollection) FindOne(ctx context.Context, id string) (*models.Event
 	params := bson.D{{Key: "_id", Value: objectId}}
 	err = c.eventCollection.FindOne(ctx, params).Decode(&event)
 	return &event, err
+}
+
+func (c *EventCollection) UpdateByID(ctx context.Context, id primitive.ObjectID, params bson.D) (*mongo.UpdateResult, error) {
+	result, err := c.eventCollection.UpdateByID(ctx, id, params)
+	if err != nil {
+		return nil, err
+	}
+	return result, err
 }
 
 type EventController struct {

--- a/server/controllers/eventControllers.go
+++ b/server/controllers/eventControllers.go
@@ -13,6 +13,8 @@ import (
 type EventCollectionInterface interface {
 	InsertOne(ctx context.Context, event *models.Event) (primitive.ObjectID, error)
 
+	FindOne(ctx context.Context, id string) (*models.Event, error)
+
 	FindAll(ctx context.Context, ids []primitive.ObjectID, events *[]models.Event) error
 }
 
@@ -37,6 +39,17 @@ func (c *EventCollection) FindAll(ctx context.Context, ids []primitive.ObjectID,
 	}
 	cursor.All(ctx, events)
 	return nil
+}
+
+func (c *EventCollection) FindOne(ctx context.Context, id string) (*models.Event, error) {
+	event := models.Event{}
+	objectId, err := primitive.ObjectIDFromHex(id)
+	if err != nil {
+		return &event, err
+	}
+	params := bson.D{{Key: "_id", Value: objectId}}
+	err = c.eventCollection.FindOne(ctx, params).Decode(&event)
+	return &event, err
 }
 
 type EventController struct {

--- a/server/controllers/project.go
+++ b/server/controllers/project.go
@@ -32,6 +32,7 @@ func (c *ProjectController) ProjectCreate(ctx context.Context, project *models.P
 	}
 	project.CreationTime = time.Now()
 	project.Tasks = []string{}
+	project.Events = []string{}
 	project.Settings = models.DefaultSettings()
 	project.Applications = make(map[string]models.ProjectApplication)
 	project.IsPublic = true
@@ -134,4 +135,14 @@ func (c *ProjectController) ProjectArrayToModel(ctx context.Context, Projects []
 
 	c.Collection(projectCollection).FindAll(ctx, projectidArr, &projectsArray)
 	return projectsArray
+}
+
+func (c *ProjectController) ProjectAddEvents(ctx context.Context, projectid string, eventids []string) {
+	update := bson.D{
+		{Key: "$addToSet", Value: bson.D{
+			{Key: "events", Value: bson.D{{Key: "$each", Value: eventids}}},
+		}},
+	}
+	id, _ := primitive.ObjectIDFromHex(projectid)
+	c.Collection(projectCollection).UpdateByID(ctx, id, update)
 }

--- a/server/controllers/project.go
+++ b/server/controllers/project.go
@@ -146,3 +146,12 @@ func (c *ProjectController) ProjectAddEvents(ctx context.Context, projectid stri
 	id, _ := primitive.ObjectIDFromHex(projectid)
 	c.Collection(projectCollection).UpdateByID(ctx, id, update)
 }
+
+func (c *ProjectController) ProjectRemoveEvents(ctx context.Context, projectid primitive.ObjectID, eventids []string) {
+	update := bson.D{
+		{Key: "$pull", Value: bson.D{
+			{Key: "events", Value: bson.D{{Key: "$in", Value: eventids}}},
+		}},
+	}
+	c.Collection(projectCollection).UpdateByID(ctx, projectid, update)
+}

--- a/server/controllers/task.go
+++ b/server/controllers/task.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/OrgaNiUS/OrgaNiUS/server/functions"
 	"github.com/OrgaNiUS/OrgaNiUS/server/models"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -46,7 +47,7 @@ func (c *TaskController) TaskModify(ctx context.Context, taskid primitive.Object
 		setParams = append(setParams, bson.E{Key: "description", Value: *description})
 	}
 	if deadline != nil {
-		parsedDeadline, _ := time.Parse("2006-01-02T15:04:05.999Z", *deadline)
+		parsedDeadline, _ := functions.StringToTime(*deadline)
 		setParams = append(setParams, bson.E{Key: "deadline", Value: parsedDeadline})
 	}
 	if isdone != nil {

--- a/server/controllers/user.go
+++ b/server/controllers/user.go
@@ -243,3 +243,12 @@ func (c *UserController) UserAddEvents(ctx context.Context, userid string, event
 	id, _ := primitive.ObjectIDFromHex(userid)
 	c.Collection(userCollection).UpdateByID(ctx, id, update)
 }
+
+func (c *UserController) UserRemoveEvents(ctx context.Context, userid primitive.ObjectID, eventids []string) {
+	update := bson.D{
+		{Key: "$pull", Value: bson.D{
+			{Key: "events", Value: bson.D{{Key: "$in", Value: eventids}}},
+		}},
+	}
+	c.Collection(userCollection).UpdateByID(ctx, userid, update)
+}

--- a/server/controllers/user.go
+++ b/server/controllers/user.go
@@ -232,3 +232,14 @@ func (c *UserController) UserDeleteInvites(ctx context.Context, userid string, p
 	id, _ := primitive.ObjectIDFromHex(userid)
 	c.Collection(userCollection).UpdateByID(ctx, id, update)
 }
+
+// adds multiple events to a user
+func (c *UserController) UserAddEvents(ctx context.Context, userid string, eventids []string) {
+	update := bson.D{
+		{Key: "$addToSet", Value: bson.D{
+			{Key: "events", Value: bson.D{{Key: "$each", Value: eventids}}},
+		}},
+	}
+	id, _ := primitive.ObjectIDFromHex(userid)
+	c.Collection(userCollection).UpdateByID(ctx, id, update)
+}

--- a/server/functions/date.go
+++ b/server/functions/date.go
@@ -1,0 +1,14 @@
+package functions
+
+import "time"
+
+// this is javascript's default format for .toISOString()
+const layout = "2006-01-02T15:04:05.999Z"
+
+func StringToTime(value string) (time.Time, error) {
+	return time.Parse(layout, value)
+}
+
+func TimeToString(t time.Time) string {
+	return t.Format(layout)
+}

--- a/server/handlers/event.go
+++ b/server/handlers/event.go
@@ -10,9 +10,9 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func EventCreate(eventController controllers.EventController, jwtParser *auth.JWTParser) gin.HandlerFunc {
+func EventCreate(userController controllers.UserController, eventController controllers.EventController, jwtParser *auth.JWTParser) gin.HandlerFunc {
 	return func(ctx *gin.Context) {
-		_, _, ok := jwtParser.GetFromJWT(ctx)
+		id, _, ok := jwtParser.GetFromJWT(ctx)
 		if !ok {
 			DisplayNotAuthorized(ctx, "not logged in")
 			return
@@ -55,7 +55,7 @@ func EventCreate(eventController controllers.EventController, jwtParser *auth.JW
 		}
 
 		if query.ProjectId == "" {
-			// TODO: place in user
+			userController.UserAddEvents(ctx, id, []string{string(event.Id.Hex())})
 		} else {
 			// TODO: place in project
 		}

--- a/server/handlers/event.go
+++ b/server/handlers/event.go
@@ -67,9 +67,25 @@ func EventCreate(userController controllers.UserController, projectController co
 	}
 }
 
-func EventGet() gin.HandlerFunc {
+func EventGet(eventController controllers.EventController, jwtParser *auth.JWTParser) gin.HandlerFunc {
 	return func(ctx *gin.Context) {
-
+		_, _, ok := jwtParser.GetFromJWT(ctx)
+		if !ok {
+			DisplayNotAuthorized(ctx, "not logged in")
+			return
+		}
+		eventid := ctx.DefaultQuery("eventid", "")
+		event, err := eventController.EventGet(ctx, eventid)
+		if err != nil {
+			DisplayError(ctx, err.Error())
+			return
+		}
+		ctx.JSON(http.StatusOK, gin.H{
+			"id":    event.Id.Hex(),
+			"name":  event.Name,
+			"start": event.Start,
+			"end":   event.End,
+		})
 	}
 }
 

--- a/server/handlers/event.go
+++ b/server/handlers/event.go
@@ -1,0 +1,33 @@
+package handlers
+
+import "github.com/gin-gonic/gin"
+
+func EventCreate() gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+
+	}
+}
+
+func EventGet() gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+
+	}
+}
+
+func EventGetAll() gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+
+	}
+}
+
+func EventModify() gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+
+	}
+}
+
+func EventDelete() gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+
+	}
+}

--- a/server/handlers/event.go
+++ b/server/handlers/event.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func EventCreate(userController controllers.UserController, eventController controllers.EventController, jwtParser *auth.JWTParser) gin.HandlerFunc {
+func EventCreate(userController controllers.UserController, projectController controllers.ProjectController, eventController controllers.EventController, jwtParser *auth.JWTParser) gin.HandlerFunc {
 	return func(ctx *gin.Context) {
 		id, _, ok := jwtParser.GetFromJWT(ctx)
 		if !ok {
@@ -54,10 +54,11 @@ func EventCreate(userController controllers.UserController, eventController cont
 			return
 		}
 
+		eventids := []string{string(event.Id.Hex())}
 		if query.ProjectId == "" {
-			userController.UserAddEvents(ctx, id, []string{string(event.Id.Hex())})
+			userController.UserAddEvents(ctx, id, eventids)
 		} else {
-			// TODO: place in project
+			projectController.ProjectAddEvents(ctx, query.ProjectId, eventids)
 		}
 
 		ctx.JSON(http.StatusCreated, gin.H{

--- a/server/handlers/project.go
+++ b/server/handlers/project.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Input parameters "projectid" : "projectid"
-func ProjectGet(userController controllers.UserController, projectController controllers.ProjectController, taskController controllers.TaskController, jwtParser *auth.JWTParser) gin.HandlerFunc {
+func ProjectGet(userController controllers.UserController, projectController controllers.ProjectController, taskController controllers.TaskController, eventController controllers.EventController, jwtParser *auth.JWTParser) gin.HandlerFunc {
 	return func(ctx *gin.Context) {
 		id, _, ok := jwtParser.GetFromJWT(ctx)
 		if !ok {
@@ -55,7 +55,7 @@ func ProjectGet(userController controllers.UserController, projectController con
 				"creationTime": project.CreationTime,
 				"members":      userArr,
 				"tasks":        taskController.TaskMapToArray(ctx, project.Tasks),
-				"events":       struct{}{}, // to be implemented
+				"events":       eventController.EventMapToArray(ctx, project.Events),
 			}
 			ctx.JSON(http.StatusOK, returnedProject)
 		}

--- a/server/handlers/task.go
+++ b/server/handlers/task.go
@@ -198,6 +198,7 @@ func TaskModify(userController controllers.UserController, taskController contro
 		taskid, err := primitive.ObjectIDFromHex(query.TaskId)
 		if err != nil {
 			DisplayError(ctx, "invalid taskid")
+			return
 		}
 
 		// Delete users from task

--- a/server/handlers/task.go
+++ b/server/handlers/task.go
@@ -2,10 +2,10 @@ package handlers
 
 import (
 	"net/http"
-	"time"
 
 	"github.com/OrgaNiUS/OrgaNiUS/server/auth"
 	"github.com/OrgaNiUS/OrgaNiUS/server/controllers"
+	"github.com/OrgaNiUS/OrgaNiUS/server/functions"
 	"github.com/OrgaNiUS/OrgaNiUS/server/models"
 	"github.com/gin-gonic/gin"
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -40,7 +40,7 @@ func TaskCreate(userController controllers.UserController, projectController con
 		task.Name = query.Name
 		task.Description = query.Description
 		if query.Deadline != "" {
-			deadline, err := time.Parse("2006-01-02T15:04:05.999Z", query.Deadline)
+			deadline, err := functions.StringToTime(query.Deadline)
 			if err != nil {
 				DisplayError(ctx, "Please provide time in proper ISO8601 format")
 				return

--- a/server/models/project.go
+++ b/server/models/project.go
@@ -12,6 +12,7 @@ type Project struct {
 	Description  string                        `bson:"description" json:"description"`
 	Members      map[string]string             `bson:"members" json:"members"` // Key: UserID, Value: Role
 	Tasks        []string                      `bson:"tasks" json:"tasks"`
+	Events       []string                      `bson:"events" json:"events"`
 	CreationTime time.Time                     `bson:"creationTime" json:"creationTime"`
 	Settings     ProjectSettings               `bson:"settings" json:"settings"`
 	Applications map[string]ProjectApplication `bson:"applications" json:"applications"` // userid -> appliication


### PR DESCRIPTION
Closes #70.

8a1ee1c fixes a long-standing bug with `refresh_jwt`.

Also, abstracted out time parsing, as events are expected to use this heavily too.

9bdaffb also fixes a minor bug with a missing return statement in Task Modify's handler.

Added:
1. Event Create
2. Event Get
3. Event Get All
4. Event Modify
5. Event Delete