### PR TITLE
Client project settings

### DIFF
--- a/api.md
+++ b/api.md
@@ -391,6 +391,7 @@ type output = {
     members: member[];
     name: string;
     tasks: Task[];
+    isPublic: boolean;
 };
 
 type member = {
@@ -546,9 +547,9 @@ User will leave the project / Project will remove current User.
 Input: A JSON body with the following **required** parameters.
 
 ```typescript
-{
+type input = {
     projectid: string;
-}
+};
 ```
 
 Status Code: 200 or 400

--- a/api.md
+++ b/api.md
@@ -554,11 +554,11 @@ PATCH "/project_leave"
 
 User will leave the project / Project will remove current User.
 
-Input: A JSON body with the following **required** parameters. 
+Input: A JSON body with the following **required** parameters.
 
 ```typescript
 {
-  projectid: string;
+    projectid: string;
 }
 ```
 

--- a/api.md
+++ b/api.md
@@ -548,6 +548,22 @@ Input: A JSON body with the following parameters. projectid is only **required**
 
 Status Code: 200 or 400
 
+### Project Leave
+
+PATCH "/project_leave"
+
+User will leave the project / Project will remove current User.
+
+Input: A JSON body with the following **required** parameters. 
+
+```typescript
+{
+  projectid: string;
+}
+```
+
+Status Code: 200 or 400
+
 ### Project Delete
 
 DELETE "/project_delete"

--- a/client/docs.md
+++ b/client/docs.md
@@ -92,6 +92,18 @@ They can work with the tasks, similarly to the user dashboard, and other feature
 
 Admins can also navigate to the project settings page from this screen. Admins can also invite others to the project from this screen. Admins can also manage user applications from this screen.
 
+The user can choose to leave the project at any time. Admin's if chose to leave, will automatically transfer admin rights to next earliest member to join project.
+
+# Project Settings
+
+Only accessible to admins of project to prevent abuse.
+
+Admin can change Name, Description, Public status, and Edit current members(currently only Remove a User). They can also choose to delete the project.
+
+If an admin deletes the project, project will be permanently deleted and all associated tasks will be deleted as well. All users involved in the project will also be removed from the project as a result.
+
+Admin can navigate to the application page from here toe manage applications to join the project.
+
 ### Task Assignment
 
 However, a small difference between Project tasks and Personal tasks is that Project tasks can be assigned to users.

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -37,19 +37,7 @@ function App() {
         return () => clearInterval(interval);
     }, [auth.axiosInstance, auth.auth.loggedIn]);
 
-    return !auth.auth.loggedIn ? (
-        <Routes>
-            <Route path="/" element={<Login />} />
-            <Route path="/registration" element={<Registration />} />
-            <Route path="/forgot_pwd" element={<ForgotPwd />} />
-            <Route path="/project_create" element={<UnauthorisedAccess />} />
-            <Route path="/projects" element={<UnauthorisedAccess />} />
-            <Route path="/project/:id" element={<UnauthorisedAccess />} />
-            <Route path="/settings" element={<UnauthorisedAccess />} />
-            <Route path="/user/:username" element={<UnauthorisedAccess />} />
-            <Route path="*" element={<PageDoesNotExist />} />
-        </Routes>
-    ) : (
+    return auth.auth.loggedIn ? (
         <DataProvider>
             <>
                 <Navbar />
@@ -65,6 +53,18 @@ function App() {
                 </Routes>
             </>
         </DataProvider>
+    ) : (
+        <Routes>
+            <Route path="/" element={<Login />} />
+            <Route path="/registration" element={<Registration />} />
+            <Route path="/forgot_pwd" element={<ForgotPwd />} />
+            <Route path="/project_create" element={<UnauthorisedAccess />} />
+            <Route path="/projects" element={<UnauthorisedAccess />} />
+            <Route path="/project/:id" element={<UnauthorisedAccess />} />
+            <Route path="/settings" element={<UnauthorisedAccess />} />
+            <Route path="/user/:username" element={<UnauthorisedAccess />} />
+            <Route path="*" element={<PageDoesNotExist />} />
+        </Routes>
     );
 }
 

--- a/client/src/api/ProjectAPI.ts
+++ b/client/src/api/ProjectAPI.ts
@@ -1,4 +1,4 @@
-import { CreateGetFunction, CreateGetFunctionWithParams, CreatePatchFunction, CreatePostFunction } from "./API";
+import { CreateDeleteFunctionWithParams, CreateGetFunction, CreateGetFunctionWithParams, CreatePatchFunction, CreatePostFunction } from "./API";
 
 type ProjectGetParams = {
     projectid: string;
@@ -19,10 +19,11 @@ type ProjectInviteData = {
 };
 export const ProjectInvite = CreatePatchFunction<ProjectInviteData>("/project_invite");
 
-type ProjectGetApplicationsParams = {
-    projectid: string;
-};
+type ProjectLeaveData = ProjectGetParams;
+export const ProjectLeave = CreatePatchFunction<ProjectLeaveData>("/project_leave");
+
 // only for admin use
+type ProjectGetApplicationsParams = ProjectGetParams;
 export const ProjectGetApplications =
     CreateGetFunctionWithParams<ProjectGetApplicationsParams>("/project_get_applications");
 
@@ -32,3 +33,20 @@ type ProjectChooseData = {
     rejectedUsers: string[];
 };
 export const ProjectChoose = CreatePatchFunction<ProjectChooseData>("/project_choose");
+
+type ProjectModifyData = {
+    name?: string;
+    projectid: string;
+    description?: string;
+    isPublic?: boolean;
+};
+export const ProjectModify = CreatePatchFunction<ProjectModifyData>("/project_modify");
+
+type ProjectRemoveUserData = {
+    projectid: string;
+    userids: string[];
+};
+export const ProjectRemoveUser = CreatePatchFunction<ProjectRemoveUserData>("/project_remove_user");
+
+type ProjectDeleteParams = ProjectGetParams;
+export const ProjectDelete = CreateDeleteFunctionWithParams<ProjectDeleteParams>("/project_delete")

--- a/client/src/components/AltModal.tsx
+++ b/client/src/components/AltModal.tsx
@@ -1,0 +1,88 @@
+import React, { useEffect } from "react";
+
+import styled, { css } from "styled-components";
+
+interface props {
+    active: boolean;
+}
+
+const Outer = styled.div<props>`
+    ${(props) =>
+        props.active
+            ? css`
+                  background-color: rgba(128, 128, 128, 0.8);
+                  transition: background-color 300ms linear;
+                  z-index: 50;
+              `
+            : css`
+                  visibility: hidden;
+              `}
+    align-items: center;
+    display: flex;
+    height: 100%;
+    justify-content: center;
+    left: 0;
+    min-height: 100vh;
+    position: fixed;
+    text-align: center;
+    top: 0;
+    width: 100%;
+`;
+
+const Inner = styled.div<props>`
+    ${(props) =>
+        props.active
+            ? css`
+                  transform: translateY(0);
+                  transition: transform linear;
+              `
+            : css`
+                  transform: translateY(calc(-50vh));
+              `}
+    background-color: white;
+    padding: 1.25rem;
+    z-index: 51;
+`;
+
+// Flexible modal that can be used for various purposes.
+// Callback function is called when the area outside the active modal is clicked, Intended to be used for closing the modal.
+const AltModal = ({
+    active,
+    body,
+    callback,
+}: {
+    active: boolean;
+    body: JSX.Element;
+    callback: () => void;
+}): JSX.Element => {
+    useEffect(() => {
+        // Escape key to close modal.
+        document.addEventListener("keydown", (event) => {
+            if (event.key === "Escape") {
+                callback();
+            }
+        });
+    }, [callback]);
+
+    const handleClose: React.MouseEventHandler<HTMLButtonElement> = (event) => {
+        // https://stackoverflow.com/a/47155034
+        // This check is done to prevent the inner div from triggering the callback function.
+        if (event.target === event.currentTarget) {
+            event.preventDefault();
+            callback();
+        }
+    };
+    return (
+        // onClick outer div (or Escape key) to trigger close
+        <Outer active={active} data-testid="outer">
+            <Inner active={active}>
+                <button className="absolute top-0 right-0 px-2 text-red-500 font-bold" onClick={handleClose}>
+                    X
+                </button>
+                {body}
+            </Inner>
+        </Outer>
+    );
+};
+
+export default AltModal;

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -7,8 +7,7 @@ import { deleteCookie } from "../functions/cookies";
 const Navbar = (): JSX.Element => {
     const auth = useContext(AuthContext);
     const navigate = useNavigate();
-    const username = auth.auth.user;
-
+    
     const handleLogout = async (e: React.MouseEvent<HTMLButtonElement>) => {
         UserLogout(
             auth.axiosInstance,

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -28,11 +28,11 @@ const Navbar = (): JSX.Element => {
             <Link to="/" className="home-icon">
                 OrgaNiUS
             </Link>
+            <Link to="/" className="navbar-icon">
+                Home
+            </Link>
             <Link to="/projects" className="navbar-icon">
                 Projects
-            </Link>
-            <Link to={linkToUser} className="navbar-icon">
-                User
             </Link>
             <Link to="/settings" className="navbar-icon">
                 Settings

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -8,7 +8,6 @@ const Navbar = (): JSX.Element => {
     const auth = useContext(AuthContext);
     const navigate = useNavigate();
     const username = auth.auth.user;
-    const linkToUser: string = "/user/" + username;
 
     const handleLogout = async (e: React.MouseEvent<HTMLButtonElement>) => {
         UserLogout(

--- a/client/src/context/DataProvider.tsx
+++ b/client/src/context/DataProvider.tsx
@@ -292,7 +292,7 @@ export const DataProvider = ({ children }: { children: JSX.Element }) => {
                     events: [],
                     tasks: tasks.map((t: ITask) => t.id),
                     creationTime: data.creationTime,
-                    isPublic: false
+                    isPublic: data.isPublic,
                 };
 
                 setProjects((p) => {

--- a/client/src/context/DataProvider.tsx
+++ b/client/src/context/DataProvider.tsx
@@ -292,6 +292,7 @@ export const DataProvider = ({ children }: { children: JSX.Element }) => {
                     events: [],
                     tasks: tasks.map((t: ITask) => t.id),
                     creationTime: data.creationTime,
+                    isPublic: false
                 };
 
                 setProjects((p) => {

--- a/client/src/context/MockDataProvider.tsx
+++ b/client/src/context/MockDataProvider.tsx
@@ -63,7 +63,7 @@ const MockDataProvider = ({
         if (condensedProject === undefined) {
             return Promise.resolve([undefined, []]);
         }
-        const project: IProject = { ...condensedProject, members: [], events: [], tasks: [], creationTime: new Date() };
+        const project: IProject = { ...condensedProject, members: [], events: [], tasks: [], creationTime: new Date(), isPublic: false };
         return Promise.resolve([project, []]);
     };
 

--- a/client/src/functions/arrays.ts
+++ b/client/src/functions/arrays.ts
@@ -32,3 +32,15 @@ export const getDeltaOfArrays = <T>(original: T[], changed: T[]): [T[], T[]] => 
 
     return [added, removed];
 };
+
+/**
+ * Removes an item from array.
+ *
+ * @param arr The array we are opearating on.
+ * @param value  The value to remove.
+ *
+ * @returns Modified array.
+ */
+export const removeFromArray = <T>(arr: Array<T>, value: T): Array<T> => { 
+  return arr.filter(item => item !== value);
+}

--- a/client/src/pages/Project.tsx
+++ b/client/src/pages/Project.tsx
@@ -450,7 +450,7 @@ const Project = (): JSX.Element => {
                         onClick={() => {
                             setShowRemModal(false);
                             setShowSettingsModal(true);
-                            setCurrUsers(project.members);
+                            setCurrUsers(project.members.filter((user) => user.id !== auth.auth.id));
                             setRemovedUsers([]);
                         }}
                     >
@@ -566,7 +566,7 @@ const Project = (): JSX.Element => {
                         body: RemoveUsersModal,
                         callback: () => {
                             setShowRemModal(false);
-                            setCurrUsers(project.members);
+                            setCurrUsers(project.members.filter((user) => user.id !== auth.auth.id));
                             setRemovedUsers([]);
                         },
                     }}

--- a/client/src/pages/Project.tsx
+++ b/client/src/pages/Project.tsx
@@ -325,7 +325,7 @@ const Project = (): JSX.Element => {
 
     const SettingsModal = (
         <>
-            <h1 className="mb-1 text-2xl">Project Settings</h1>
+            <h1 className="mb-1 text-2xl underline underline-offset-auto">Project Settings</h1>
 
             <div className="w-full flex-col">
                 {/* <h1>Change Name</h1> */}
@@ -390,7 +390,7 @@ const Project = (): JSX.Element => {
 
     const RemoveUsersModal = (
         <>
-            <h1 className="mb-1 text-2xl">Edit Users</h1>
+            <h1 className="mb-1 text-2xl underline underline-offset-auto">Edit Users</h1>
             <div className="w-full flex-col" key={currUsers.length}>
                 <div className="w-full ">
                     Current Users:
@@ -584,7 +584,7 @@ const Project = (): JSX.Element => {
                     {showInviteWindow && <ProjectsInvite {...{ projectid, setShowInviteWindow }} />}
                     <Row className="my-2">
                         <Link to="/projects">⬅️ Back to Projects</Link>
-                        <ButtonArray className="border-2 rounded border-orange-400 bg-orange-300">
+                        <ButtonArray className="border-2 rounded border-orange-300 bg-orange-200">
                             {isAdmin ? (
                                 <Button onClick={() => setShowSettingsModal(true)}>Settings</Button>
                             ) : (

--- a/client/src/pages/Project.tsx
+++ b/client/src/pages/Project.tsx
@@ -328,7 +328,6 @@ const Project = (): JSX.Element => {
             <h1 className="mb-1 text-2xl underline underline-offset-auto">Project Settings</h1>
 
             <div className="w-full flex-col">
-                {/* <h1>Change Name</h1> */}
                 <div className="flex w-full justify-start">
                     <input
                         className="w-80 border-2 border-gray-200 rounded"
@@ -340,7 +339,6 @@ const Project = (): JSX.Element => {
                         Change
                     </Button>
                 </div>
-                {/* <label>Change Description</label> */}
                 <div className="flex-col w-full">
                     <input
                         className="w-80 border-2 border-gray-200 rounded"

--- a/client/src/pages/Project.tsx
+++ b/client/src/pages/Project.tsx
@@ -1,7 +1,7 @@
 import { useContext, useEffect, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import styled from "styled-components";
-import { ProjectDelete, ProjectModify } from "../api/ProjectAPI";
+import { ProjectDelete, ProjectLeave, ProjectModify, ProjectRemoveUser } from "../api/ProjectAPI";
 import Modal from "../components/Modal";
 import PreLoader from "../components/PreLoader";
 import ProjectsInvite from "../components/Projects/ProjectsInvite";
@@ -11,8 +11,9 @@ import { TodoProvider } from "../components/Todo/TodoProvider";
 import AuthContext from "../context/AuthProvider";
 import { DataContext } from "../context/DataProvider";
 import { filterTaskOptions, mergeEventArrays } from "../functions/events";
-import { BaseButton } from "../styles";
-import { IEvent, IProject, ITask } from "../types";
+import { BaseButton, NoEffectButton } from "../styles";
+import { IEvent, IProject, ITask, IUser } from "../types";
+import { removeFromArray } from "../functions/arrays";
 
 const Title = styled.h1`
     font-size: 2rem;
@@ -61,8 +62,13 @@ const Button2 = styled(Button)`
 
 const ButtonDeleteProject = styled(BaseButton)`
     background-color: rgb(255, 0, 90);
-    width: 80%;
+    width: 45%;
 `;
+
+const ButtonLeaveProject = styled(BaseButton)`
+    background-color: rgb(255, 0, 90);
+`;
+
 const ButtonConfirmDelete = styled(BaseButton)`
     background-color: rgb(255, 0, 90);
     border: 1px solid rgb(255, 0, 90);
@@ -94,8 +100,13 @@ const Project = (): JSX.Element => {
     const [newName, setNewName] = useState<string>();
     const [newDesc, setNewDesc] = useState<string>();
     const [isPublic, setPublic] = useState<boolean>();
+    const [currUsers, setCurrUsers] = useState<Array<IUser>>([]);
+    const [removedUsers, setRemovedUsers] = useState<Array<IUser>>([]);
+
     const [showSettingsModal, setShowSettingsModal] = useState<boolean>(false);
     const [showDeleteModal, setShowDeleteModal] = useState<boolean>(false);
+    const [showRemModal, setShowRemModal] = useState<boolean>(false);
+    const [showLeaveModal, setShowLeaveModal] = useState<boolean>(false);
 
     const doneTrigger = (task: ITask) => {
         data.patchTask(
@@ -189,26 +200,34 @@ const Project = (): JSX.Element => {
             setProject(project);
             setTasks(tasks);
             setLoading(false);
-            setPublic(project?.isPublic)
         });
 
         // Debugging purposes
         // setProject({
-        //     id: "",
+        //     id: "5215321",
         //     name: "Trial Project",
-        //     description: "sample description",
-        //     members: [],
+        //     description: "testsfasfasafsa description",
+        //     members: [
+        //         { id: "123111", name: "USER1", role: "admin" },
+        //         { id: "123222", name: "USER2", role: "member" },
+        //         { id: "123333", name: "USER3", role: "member" },
+        //     ],
         //     events: [],
         //     tasks: [],
         //     creationTime: new Date(),
         //     isPublic: false,
         // });
         // setLoading(false);
-        // setPublic(true);
-
         // including data.getProject and id will cause this to continuously fire
         // eslint-disable-next-line
     }, []);
+
+    useEffect(() => {
+        if (project) {
+            setCurrUsers(project.members.filter((user) => user.id !== auth.auth.id));
+            setPublic(project.isPublic);
+        }
+    }, [project]);
 
     if (project === undefined || projectid === undefined) {
         return (
@@ -261,17 +280,48 @@ const Project = (): JSX.Element => {
         );
     };
 
-    const handleDelete: React.MouseEventHandler<HTMLButtonElement> = (event) => { 
+    const handleDelete: React.MouseEventHandler<HTMLButtonElement> = (event) => {
         event.preventDefault();
         ProjectDelete(
             auth.axiosInstance,
             { projectid: projectid },
-            () => { 
-                navigate("/projects")
+            () => {
+                navigate("/projects");
+                window.location.reload();
             },
             () => {}
-        )
-    }
+        );
+    };
+
+    const handleRemoveUsers: React.MouseEventHandler<HTMLButtonElement> = (e) => {
+        e.preventDefault();
+        ProjectRemoveUser(
+            auth.axiosInstance,
+            { projectid: projectid, userids: removedUsers.map((user) => user.id) },
+            () => {
+                setShowRemModal(false);
+                setShowSettingsModal(true);
+                window.location.reload();
+            },
+            () => {
+                setShowRemModal(false);
+                setShowSettingsModal(true);
+            }
+        );
+    };
+
+    const handleLeaveProject: React.MouseEventHandler<HTMLButtonElement> = (event) => {
+        event.preventDefault();
+        ProjectLeave(
+            auth.axiosInstance,
+            { projectid: projectid },
+            () => {
+                navigate("/projects");
+                window.location.reload();
+            },
+            () => {}
+        );
+    };
 
     const SettingsModal = (
         <>
@@ -303,6 +353,19 @@ const Project = (): JSX.Element => {
                     </Button>
                 </div>
                 <div className="mt-2">
+                    <Button2
+                        onClick={() => {
+                            setShowRemModal(true);
+                            setShowSettingsModal(false);
+                        }}
+                    >
+                        Edit Users
+                    </Button2>
+                    <Button2>
+                        <Link to={`/project_applications/${projectid}`}>User Join Requests</Link>
+                    </Button2>
+                </div>
+                <div className="mt-2">
                     {isPublic ? (
                         <Button2 type="submit" onClick={handleChangePublic}>
                             Make Private
@@ -312,16 +375,89 @@ const Project = (): JSX.Element => {
                             Make Public
                         </Button2>
                     )}
-                    <Button2 type="submit">Remove Users</Button2>
+                    <ButtonDeleteProject
+                        onClick={() => {
+                            setShowDeleteModal(true);
+                            setShowSettingsModal(false);
+                        }}
+                    >
+                        Delete Project
+                    </ButtonDeleteProject>
                 </div>
-                <ButtonDeleteProject
-                    onClick={() => {
-                        setShowDeleteModal(true);
-                        setShowSettingsModal(false);
-                    }}
-                >
-                    Delete Project
-                </ButtonDeleteProject>
+            </div>
+        </>
+    );
+
+    const RemoveUsersModal = (
+        <>
+            <h1 className="mb-1 text-2xl">Edit Users</h1>
+            <div className="w-full flex-col" key={currUsers.length}>
+                <div className="w-full ">
+                    Current Users:
+                    <div className="w-80">
+                        {currUsers.map((User) => {
+                            return (
+                                <>
+                                    <li className="flex flex-row mt-1 border-2 items-center rounded" key={User.id}>
+                                        <div className="flex justify-items-start flex-grow">{User.name}</div>
+                                        <Button
+                                            className="flex justify-end"
+                                            onClick={() => {
+                                                let tempRemovedUsers = removedUsers;
+                                                tempRemovedUsers.push(User);
+                                                setRemovedUsers(tempRemovedUsers);
+                                                let tempCurrUsers = currUsers;
+                                                tempCurrUsers = removeFromArray(tempCurrUsers, User);
+                                                setCurrUsers(tempCurrUsers);
+                                            }}
+                                        >
+                                            Remove
+                                        </Button>
+                                    </li>
+                                </>
+                            );
+                        })}
+                    </div>
+                </div>
+                <div className="w-full flex-col">
+                    Users to be Removed:
+                    <div className="w-80">
+                        {removedUsers.map((User) => {
+                            return (
+                                <>
+                                    <li className="flex flex-row mt-1 border-2 items-center rounded" key={User.id}>
+                                        <div className="flex justify-items-start flex-grow">{User.name}</div>
+                                        <Button
+                                            onClick={() => {
+                                                let tempRemovedUsers = removedUsers;
+                                                let tempCurrUsers = currUsers;
+                                                tempCurrUsers.push(User);
+                                                setCurrUsers(tempCurrUsers);
+                                                tempRemovedUsers = removeFromArray(tempRemovedUsers, User);
+                                                setRemovedUsers(tempRemovedUsers);
+                                            }}
+                                        >
+                                            Don't Remove
+                                        </Button>
+                                    </li>
+                                </>
+                            );
+                        })}
+                    </div>
+                </div>
+                <div className="mt-2">
+                    <Button2
+                        onClick={() => {
+                            setShowRemModal(false);
+                            setShowSettingsModal(true);
+                            setCurrUsers(project.members);
+                            setRemovedUsers([]);
+                        }}
+                    >
+                        Cancel
+                    </Button2>
+                    <Button2 onClick={handleRemoveUsers}>Confirm</Button2>
+                </div>
             </div>
         </>
     );
@@ -352,6 +488,38 @@ const Project = (): JSX.Element => {
                 onClick={() => {
                     setShowDeleteModal(false);
                     setShowSettingsModal(true);
+                }}
+            >
+                Cancel
+            </ButtonConfirmCancel>
+        </>
+    );
+
+    const LeaveModal = (
+        <>
+            <div>
+                <svg
+                    // SVG from https://heroicons.com/
+                    xmlns="http://www.w3.org/2000/svg"
+                    className="h-6 w-8 pr-2 align-bottom inline"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                >
+                    <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+                    />
+                </svg>
+                Are you sure you want to leave this project?
+            </div>
+            <div>You will need to apply/get invited to join the project again.</div>
+            <ButtonConfirmDelete onClick={handleLeaveProject}>Confirm</ButtonConfirmDelete>
+            <ButtonConfirmCancel
+                onClick={() => {
+                    setShowLeaveModal(false);
                 }}
             >
                 Cancel
@@ -392,32 +560,49 @@ const Project = (): JSX.Element => {
                         },
                     }}
                 />
+                <Modal
+                    {...{
+                        active: showRemModal,
+                        body: RemoveUsersModal,
+                        callback: () => {
+                            setShowRemModal(false);
+                            setCurrUsers(project.members);
+                            setRemovedUsers([]);
+                        },
+                    }}
+                />
+                <Modal
+                    {...{
+                        active: showLeaveModal,
+                        body: LeaveModal,
+                        callback: () => {
+                            setShowLeaveModal(false);
+                        },
+                    }}
+                />
                 <Container>
                     {showInviteWindow && <ProjectsInvite {...{ projectid, setShowInviteWindow }} />}
                     <Row className="my-2">
                         <Link to="/projects">⬅️ Back to Projects</Link>
-                        <ButtonArray>
+                        <ButtonArray className="border-2 rounded border-orange-400 bg-orange-300">
                             {isAdmin ? (
                                 <Button onClick={() => setShowSettingsModal(true)}>Settings</Button>
                             ) : (
-                                <Button disabled>Settings</Button>
+                                <NoEffectButton disabled className="bg-slate-400">
+                                    Settings
+                                </NoEffectButton>
                             )}
-                            <Button disabled={!isAdmin}>
-                                {isAdmin ? (
-                                    // show link only if is admin (else just regular disabled button)
-                                    <Link to={`/project_applications/${projectid}`}>Applications</Link>
-                                ) : (
-                                    "Applications"
-                                )}
-                            </Button>
                             <Button onClick={() => setShowInviteWindow(true)} disabled={!isAdmin}>
                                 Invite
                             </Button>
+                            <ButtonLeaveProject onClick={() => {
+                                setShowLeaveModal(true);
+                            }}>Leave Project</ButtonLeaveProject>
                         </ButtonArray>
                     </Row>
                     <Row>
                         <LeftBox>
-                            <Title>{project.name}</Title>
+                            <Title className="underline underline-offset-auto">{project.name}</Title>
                             <ProjectContent>{project.description}</ProjectContent>
                             <ProjectContent>Members: {project.members.map((m) => m.name).join(", ")}</ProjectContent>
                         </LeftBox>

--- a/client/src/pages/Project.tsx
+++ b/client/src/pages/Project.tsx
@@ -1,6 +1,8 @@
 import { useContext, useEffect, useState } from "react";
-import { Link, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import styled from "styled-components";
+import { ProjectDelete, ProjectModify } from "../api/ProjectAPI";
+import Modal from "../components/Modal";
 import PreLoader from "../components/PreLoader";
 import ProjectsInvite from "../components/Projects/ProjectsInvite";
 import Timeline from "../components/Timeline";
@@ -53,9 +55,35 @@ const Button = styled(BaseButton)`
     background-color: rgb(59, 130, 246);
 `;
 
+const Button2 = styled(Button)`
+    width: 45%;
+`;
+
+const ButtonDeleteProject = styled(BaseButton)`
+    background-color: rgb(255, 0, 90);
+    width: 80%;
+`;
+const ButtonConfirmDelete = styled(BaseButton)`
+    background-color: rgb(255, 0, 90);
+    border: 1px solid rgb(255, 0, 90);
+    float: centre;
+    margin-left: 0.75rem;
+    margin-top: 1rem;
+`;
+
+const ButtonConfirmCancel = styled(BaseButton)`
+    background-color: white;
+    border: 1px solid black;
+    color: black;
+    float: centre;
+    margin-top: 1rem;
+    margin-left: 0.75rem;
+`;
+
 const Project = (): JSX.Element => {
     const auth = useContext(AuthContext);
     const data = useContext(DataContext);
+    const navigate = useNavigate();
 
     const { id: projectid } = useParams();
     const [loading, setLoading] = useState<boolean>(true);
@@ -63,6 +91,11 @@ const Project = (): JSX.Element => {
     const [tasks, setTasks] = useState<ITask[]>([]);
     const [showInviteWindow, setShowInviteWindow] = useState<boolean>(false);
     const isAdmin: boolean = project?.members.find((u) => u.name === auth.auth.user)?.role === "admin";
+    const [newName, setNewName] = useState<string>();
+    const [newDesc, setNewDesc] = useState<string>();
+    const [isPublic, setPublic] = useState<boolean>();
+    const [showSettingsModal, setShowSettingsModal] = useState<boolean>(false);
+    const [showDeleteModal, setShowDeleteModal] = useState<boolean>(false);
 
     const doneTrigger = (task: ITask) => {
         data.patchTask(
@@ -156,7 +189,22 @@ const Project = (): JSX.Element => {
             setProject(project);
             setTasks(tasks);
             setLoading(false);
+            setPublic(project?.isPublic)
         });
+
+        // Debugging purposes
+        // setProject({
+        //     id: "",
+        //     name: "Trial Project",
+        //     description: "sample description",
+        //     members: [],
+        //     events: [],
+        //     tasks: [],
+        //     creationTime: new Date(),
+        //     isPublic: false,
+        // });
+        // setLoading(false);
+        // setPublic(true);
 
         // including data.getProject and id will cause this to continuously fire
         // eslint-disable-next-line
@@ -173,6 +221,144 @@ const Project = (): JSX.Element => {
         );
     }
 
+    const handleChangeName: React.MouseEventHandler<HTMLButtonElement> = (event) => {
+        event.preventDefault();
+        ProjectModify(
+            auth.axiosInstance,
+            { name: newName, projectid: projectid },
+            () => {
+                project.name = newName ?? project.name;
+            },
+            () => {
+                setNewName(undefined);
+            }
+        );
+    };
+
+    const handleChangeDesc: React.MouseEventHandler<HTMLButtonElement> = (event) => {
+        event.preventDefault();
+        ProjectModify(
+            auth.axiosInstance,
+            { description: newDesc, projectid: projectid },
+            () => {
+                project.description = newDesc ?? project.description;
+            },
+            () => {
+                setNewDesc(undefined);
+            }
+        );
+    };
+
+    const handleChangePublic: React.MouseEventHandler<HTMLButtonElement> = (event) => {
+        event.preventDefault();
+        ProjectModify(
+            auth.axiosInstance,
+            { isPublic: !isPublic, projectid: projectid },
+            () => {
+                setPublic(!isPublic);
+            },
+            () => {}
+        );
+    };
+
+    const handleDelete: React.MouseEventHandler<HTMLButtonElement> = (event) => { 
+        event.preventDefault();
+        ProjectDelete(
+            auth.axiosInstance,
+            { projectid: projectid },
+            () => { 
+                navigate("/projects")
+            },
+            () => {}
+        )
+    }
+
+    const SettingsModal = (
+        <>
+            <h1 className="mb-1 text-2xl">Project Settings</h1>
+
+            <div className="w-full flex-col">
+                {/* <h1>Change Name</h1> */}
+                <div className="flex w-full justify-start">
+                    <input
+                        className="w-80 border-2 border-gray-200 rounded"
+                        type="text"
+                        placeholder="New Project Name"
+                        onChange={(e) => setNewName(e.target.value)}
+                    ></input>
+                    <Button type="submit" onClick={handleChangeName}>
+                        Change
+                    </Button>
+                </div>
+                {/* <label>Change Description</label> */}
+                <div className="flex-col w-full">
+                    <input
+                        className="w-80 border-2 border-gray-200 rounded"
+                        type="text"
+                        placeholder="New Description"
+                        onChange={(e) => setNewDesc(e.target.value)}
+                    ></input>
+                    <Button type="submit" onClick={handleChangeDesc}>
+                        Change
+                    </Button>
+                </div>
+                <div className="mt-2">
+                    {isPublic ? (
+                        <Button2 type="submit" onClick={handleChangePublic}>
+                            Make Private
+                        </Button2>
+                    ) : (
+                        <Button2 type="submit" onClick={handleChangePublic}>
+                            Make Public
+                        </Button2>
+                    )}
+                    <Button2 type="submit">Remove Users</Button2>
+                </div>
+                <ButtonDeleteProject
+                    onClick={() => {
+                        setShowDeleteModal(true);
+                        setShowSettingsModal(false);
+                    }}
+                >
+                    Delete Project
+                </ButtonDeleteProject>
+            </div>
+        </>
+    );
+
+    const DeleteModal = (
+        <>
+            <div>
+                <svg
+                    // SVG from https://heroicons.com/
+                    xmlns="http://www.w3.org/2000/svg"
+                    className="h-6 w-8 pr-2 align-bottom inline"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                >
+                    <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+                    />
+                </svg>
+                Are you sure you want to delete this account?
+            </div>
+            <div>This is irreversible.</div>
+            <ButtonConfirmDelete onClick={handleDelete}>Confirm</ButtonConfirmDelete>
+            <ButtonConfirmCancel
+                onClick={() => {
+                    setShowDeleteModal(false);
+                    setShowSettingsModal(true);
+                }}
+            >
+                Cancel
+            </ButtonConfirmCancel>
+        </>
+    );
+
     return (
         <TodoProvider
             {...{
@@ -187,40 +373,63 @@ const Project = (): JSX.Element => {
                 members: project.members,
             }}
         >
-            <Container>
-                {showInviteWindow && <ProjectsInvite {...{ projectid, setShowInviteWindow }} />}
-                <Row className="my-2">
-                    <Link to="/projects">⬅️ Back to Projects</Link>
-                    <ButtonArray>
-                        {/* TODO: in future, add !isAdmin similarly to button below */}
-                        <Button disabled>Settings</Button>
-                        <Button disabled={!isAdmin}>
+            <>
+                <Modal
+                    {...{
+                        active: showDeleteModal,
+                        body: DeleteModal,
+                        callback: () => {
+                            setShowDeleteModal(false);
+                        },
+                    }}
+                />
+                <Modal
+                    {...{
+                        active: showSettingsModal,
+                        body: SettingsModal,
+                        callback: () => {
+                            setShowSettingsModal(false);
+                        },
+                    }}
+                />
+                <Container>
+                    {showInviteWindow && <ProjectsInvite {...{ projectid, setShowInviteWindow }} />}
+                    <Row className="my-2">
+                        <Link to="/projects">⬅️ Back to Projects</Link>
+                        <ButtonArray>
                             {isAdmin ? (
-                                // show link only if is admin (else just regular disabled button)
-                                <Link to={`/project_applications/${projectid}`}>Applications</Link>
+                                <Button onClick={() => setShowSettingsModal(true)}>Settings</Button>
                             ) : (
-                                "Applications"
+                                <Button disabled>Settings</Button>
                             )}
-                        </Button>
-                        <Button onClick={() => setShowInviteWindow(true)} disabled={!isAdmin}>
-                            Invite
-                        </Button>
-                    </ButtonArray>
-                </Row>
-                <Row>
-                    <LeftBox>
-                        <Title>{project.name}</Title>
-                        <ProjectContent>{project.description}</ProjectContent>
-                        <ProjectContent>Members: {project.members.map((m) => m.name).join(", ")}</ProjectContent>
-                    </LeftBox>
-                    <RightBox>
-                        <TodoGrid {...{ view: "project" }} />
-                    </RightBox>
-                </Row>
-                <div className="h-4">
-                    <Timeline {...{ events: mergedEvents }} />
-                </div>
-            </Container>
+                            <Button disabled={!isAdmin}>
+                                {isAdmin ? (
+                                    // show link only if is admin (else just regular disabled button)
+                                    <Link to={`/project_applications/${projectid}`}>Applications</Link>
+                                ) : (
+                                    "Applications"
+                                )}
+                            </Button>
+                            <Button onClick={() => setShowInviteWindow(true)} disabled={!isAdmin}>
+                                Invite
+                            </Button>
+                        </ButtonArray>
+                    </Row>
+                    <Row>
+                        <LeftBox>
+                            <Title>{project.name}</Title>
+                            <ProjectContent>{project.description}</ProjectContent>
+                            <ProjectContent>Members: {project.members.map((m) => m.name).join(", ")}</ProjectContent>
+                        </LeftBox>
+                        <RightBox>
+                            <TodoGrid {...{ view: "project" }} />
+                        </RightBox>
+                    </Row>
+                    <div className="h-4">
+                        <Timeline {...{ events: mergedEvents }} />
+                    </div>
+                </Container>
+            </>
         </TodoProvider>
     );
 };

--- a/client/src/pages/ProjectCreate.tsx
+++ b/client/src/pages/ProjectCreate.tsx
@@ -121,6 +121,7 @@ const ProjectCreate = (): JSX.Element => {
             events: [],
             tasks: [],
             creationTime: new Date(),
+            isPublic: false,
         };
 
         setState("loading");

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -274,7 +274,7 @@ const Settings = (): JSX.Element => {
             />
             <Container>
                 <Left>
-                    <H1>Setings</H1>
+                    <H1>Settings</H1>
                     {keys.map((key, i) => {
                         return (
                             <div key={i}>

--- a/client/src/styles.ts
+++ b/client/src/styles.ts
@@ -15,6 +15,13 @@ export const BaseButton = styled.button`
     }
 `;
 
+export const NoEffectButton = styled.button`
+    border-radius: 6px; /* border-radius for rounded button */
+    color: white;
+    margin: 0.25rem;
+    padding: 0.1rem 0.5rem;
+`;
+
 // for buttons that are a SVG icon
 export const IconButton = styled.button`
     transition: transform 0.2s;

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -48,6 +48,7 @@ export interface IProject {
     events: string[]; // storing only ids
     tasks: string[]; // storing only ids
     creationTime: Date;
+    isPublic: boolean;
 }
 
 export interface IProjectSettings {

--- a/main.go
+++ b/main.go
@@ -64,6 +64,7 @@ func handleRoutes(URL string, router *gin.Engine, userController controllers.Use
 	v1.GET("/project_get_applications", handlers.ProjectGetApplicants(userController, projectController, jwtParser))
 	v1.PATCH("/project_choose", handlers.ProjectChooseUsers(userController, projectController, jwtParser))
 	v1.PATCH("/project_remove_user", handlers.ProjectRemoveUsers(userController, projectController, jwtParser))
+	v1.PATCH("/project_leave", handlers.ProjectLeave(userController, projectController, taskController, jwtParser))
 	v1.DELETE("/project_delete", handlers.ProjectDelete(userController, projectController, taskController, jwtParser))
 
 	v1.POST("/task_create", handlers.TaskCreate(userController, projectController, taskController, jwtParser))

--- a/server/controllers/project.go
+++ b/server/controllers/project.go
@@ -36,7 +36,7 @@ func (c *ProjectController) ProjectCreate(ctx context.Context, project *models.P
 	project.Events = []string{}
 	project.Settings = models.DefaultSettings()
 	project.Applications = make(map[string]models.ProjectApplication)
-	project.IsPublic = true
+	project.IsPublic = false
 
 	id, err := c.Collection(projectCollection).InsertOne(ctx, project)
 

--- a/server/controllers/task.go
+++ b/server/controllers/task.go
@@ -127,3 +127,13 @@ func (c *TaskController) TaskMapToArray(ctx context.Context, Tasks []string) []m
 	c.Collection(taskCollection).FindAll(ctx, taskPrimitiveIdArr, &tasksArray)
 	return tasksArray
 }
+
+func (c *TaskController) TasksDeleteUser(ctx context.Context, Tasks []string, userId string) {
+	primitiveArr := []primitive.ObjectID{}
+	for _, taskid := range Tasks {
+		id, _ := primitive.ObjectIDFromHex(taskid)
+		primitiveArr = append(primitiveArr, id)
+	}
+	params := bson.D{{Key: "$pull", Value: bson.D{{Key: "assignedTo", Value: userId}}}}
+	c.Collection(taskCollection).UpdateManyByID(ctx, primitiveArr, params)
+}

--- a/server/controllers/taskControllers.go
+++ b/server/controllers/taskControllers.go
@@ -25,6 +25,9 @@ type TaskCollectionInterface interface {
 	// Modifies a task by ID
 	UpdateByID(ctx context.Context, id primitive.ObjectID, params bson.D) (*mongo.UpdateResult, error)
 
+	// Modifies many tasks by ID
+	UpdateManyByID(ctx context.Context, taskIdArr []primitive.ObjectID, params bson.D) (*mongo.UpdateResult, error)
+
 	// Deletes a task by ID
 	DeleteByID(ctx context.Context, id string) (int64, error)
 
@@ -79,6 +82,18 @@ func (c *TaskCollection) UpdateByID(ctx context.Context, id primitive.ObjectID, 
 		return nil, err
 	}
 	return result, err
+}
+
+func (c *TaskCollection) UpdateManyByField(ctx context.Context, field string, arr interface{}, params bson.D) (*mongo.UpdateResult, error) {
+	result, err := c.taskCollection.UpdateMany(ctx, bson.D{{Key: field, Value: bson.D{{Key: "$in", Value: arr}}}}, params)
+	if err != nil {
+		return nil, err
+	}
+	return result, err
+}
+
+func (c *TaskCollection) UpdateManyByID(ctx context.Context, taskidArr []primitive.ObjectID, params bson.D) (*mongo.UpdateResult, error) {
+	return c.UpdateManyByField(ctx, "_id", taskidArr, params)
 }
 
 func (c *TaskCollection) DeleteByID(ctx context.Context, id string) (int64, error) {

--- a/server/handlers/project.go
+++ b/server/handlers/project.go
@@ -480,9 +480,8 @@ func ProjectLeave(userController controllers.UserController, projectController c
 		// Delete all project tasks from user.Tasks
 		for _, taskid := range project.Tasks {
 			delete(user.Tasks, taskid)
-			// primTaskId, _ := primitive.ObjectIDFromHex(taskid)
-			// taskController.TaskModify(ctx, primTaskId, nil, nil, nil, nil, nil, &useridArr, nil, nil)
 		}
+		
 		// Remove User from all project.Tasks.assignedTo
 		taskController.TasksDeleteUser(ctx, project.Tasks, id)
 		userController.UserModifyTask(ctx, &user)

--- a/server/handlers/project.go
+++ b/server/handlers/project.go
@@ -55,6 +55,7 @@ func ProjectGet(userController controllers.UserController, projectController con
 				"creationTime": project.CreationTime,
 				"members":      userArr,
 				"tasks":        taskController.TaskMapToArray(ctx, project.Tasks),
+				"isPublic":     project.IsPublic,
 				"events":       struct{}{}, // to be implemented
 			}
 			ctx.JSON(http.StatusOK, returnedProject)
@@ -423,7 +424,7 @@ func ProjectLeave(userController controllers.UserController, projectController c
 			return
 		}
 		type Query struct {
-			Id  string `bson:"projectid" json:"projectid"`
+			Id string `bson:"projectid" json:"projectid"`
 		}
 		var query Query
 		if err := ctx.BindJSON(&query); err != nil {

--- a/server/handlers/project.go
+++ b/server/handlers/project.go
@@ -468,10 +468,11 @@ func ProjectLeave(userController controllers.UserController, projectController c
 		// Delete all project tasks from user.Tasks
 		for _, taskid := range project.Tasks {
 			delete(user.Tasks, taskid)
-			primTaskId, _ := primitive.ObjectIDFromHex(taskid)
-			// Remove User from all project.Tasks.assignedTo
-			taskController.TaskModify(ctx, primTaskId, nil, nil, nil, nil, nil, &useridArr, nil, nil)
+			// primTaskId, _ := primitive.ObjectIDFromHex(taskid)
+			// taskController.TaskModify(ctx, primTaskId, nil, nil, nil, nil, nil, &useridArr, nil, nil)
 		}
+		// Remove User from all project.Tasks.assignedTo
+		taskController.TasksDeleteUser(ctx, project.Tasks, id)
 		userController.UserModifyTask(ctx, &user)
 
 		// delete projectid from user.projects

--- a/server/handlers/project.go
+++ b/server/handlers/project.go
@@ -442,8 +442,10 @@ func ProjectLeave(userController controllers.UserController, projectController c
 		user, err := userController.UserRetrieve(ctx, id, "")
 		if err == mongo.ErrNoDocuments {
 			DisplayError(ctx, "user does not exist")
+			return
 		} else if err != nil {
 			DisplayError(ctx, err.Error())
+			return
 		}
 		useridArr := []string{id}
 

--- a/server/handlers/project.go
+++ b/server/handlers/project.go
@@ -449,13 +449,25 @@ func ProjectLeave(userController controllers.UserController, projectController c
 		}
 		useridArr := []string{id}
 
-		// If user is admin, assign someone else admin role
+		// If user is admin & there are no other admins in the project, assign someone else admin role.
 		if len(project.Members) > 1 {
 			if project.Settings.Roles[project.Members[id]].IsAdmin {
+				onlyAdmin := true
 				for nextUserId := range project.Members {
-					if nextUserId != id {
-						project.Members[nextUserId] = "admin"
+					if nextUserId == id {
+						continue
+					}
+					if project.Members[nextUserId] == "admin" {
+						onlyAdmin = false
 						break
+					}
+				}
+				if onlyAdmin {
+					for nextUserId := range project.Members {
+						if nextUserId != id {
+							project.Members[nextUserId] = "admin"
+							break
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Closes #83 
Closes #79  
Closes #78  
Implemented Project Settings page, uses a modal for most operations. Will need to edit modal transition animation for current use case.

![image](https://user-images.githubusercontent.com/76719133/179614215-901dd39d-c73d-4783-8c6d-dd32e9ef88af.png)

No confirmations for changing Name, Description or Public status.

Delete project and leave project will pop similar modal as Delete user.

Users can click on edit users to remove users.
![image](https://user-images.githubusercontent.com/76719133/179614507-55c4a09b-32ab-4391-a572-a2f09bd56564.png)
![image](https://user-images.githubusercontent.com/76719133/179614548-e19b329c-3390-4201-a2b9-6a76f59962bd.png)

Confirm to remove users, no further confirmation is needed. Page will refresh and changes will be reflected.

Leave project will transfer ownership to next member if current user is admin,

Deleting or leaving project will redirect to projects page.