### PR TITLE
Server iCalendar

### DIFF
--- a/api.md
+++ b/api.md
@@ -807,6 +807,18 @@ type output = {
 };
 ```
 
+### Event Parse iCalendar (.ics) file
+
+POST "/event_ics" with multipart-form data.
+
+Input: Key of "ics_file" with value being the actual iCalendar file.
+
+```typescript
+type output = {
+    events: Event[];
+};
+```
+
 ## Definitions
 
 ```typescript

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 )
 
 require (
+	github.com/arran4/golang-ical v0.0.0-20220517104411-fd89fefb0182 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-playground/locales v0.14.0 // indirect
 	github.com/go-playground/universal-translator v0.18.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/arran4/golang-ical v0.0.0-20220517104411-fd89fefb0182 h1:mUsKridvWp4dgfkO/QWtgGwuLtZYpjKgsm15JRRik3o=
+github.com/arran4/golang-ical v0.0.0-20220517104411-fd89fefb0182/go.mod h1:BSTTrYHuM12oAL8jDdcmPdw02SBThKYWNFHQlvEG6b0=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -68,6 +70,7 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -150,6 +153,7 @@ google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscL
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=

--- a/main.go
+++ b/main.go
@@ -77,6 +77,7 @@ func handleRoutes(router *gin.Engine, userController controllers.UserController,
 	v1.PATCH("/event_modify", handlers.EventModify(eventController, jwtParser))
 	v1.DELETE("/event_delete", handlers.EventDelete(userController, projectController, eventController, jwtParser))
 	v1.POST("/event_nusmods", handlers.EventNusmods(userController, eventController, jwtParser))
+	v1.POST("/event_ics", handlers.EventIcs(userController, eventController, jwtParser))
 
 	// web socket handlers here
 	v1.GET("/project_search", handlers.ProjectSearch(projectController, jwtParser))

--- a/server/ics/ics.go
+++ b/server/ics/ics.go
@@ -1,0 +1,44 @@
+package ics
+
+import (
+	"mime/multipart"
+
+	"github.com/OrgaNiUS/OrgaNiUS/server/models"
+	ical "github.com/arran4/golang-ical"
+)
+
+// Simple parsing of ics file to our models.Event form.
+func Parse(fileReader multipart.File) ([]*models.Event, error) {
+	var events []*models.Event
+	calendar, err := ical.ParseCalendar(fileReader)
+	if err != nil {
+		return events, err
+	}
+	vevents := calendar.Events()
+	for _, vevent := range vevents {
+		// vevent summary = name
+		ianaproperty := vevent.GetProperty(ical.ComponentPropertySummary)
+		name := ianaproperty.Value
+		if name == "" {
+			// just skip events that have problems
+			continue
+		}
+		start, err := vevent.GetStartAt()
+		if err != nil {
+			// just skip events that have problems
+			continue
+		}
+		end, err := vevent.GetEndAt()
+		if err != nil {
+			// just skip events that have problems
+			continue
+		}
+		event := &models.Event{
+			Name:  name,
+			Start: start,
+			End:   end,
+		}
+		events = append(events, event)
+	}
+	return events, nil
+}


### PR DESCRIPTION
Closes #72.

Installed arran4/golang-ical library to make life much easier.

Does not support repeating events (only takes the first event).